### PR TITLE
Fix maximum call stack issue, add some more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "5"
+  - "4"

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function from (source) {
     if(s.ended) return
     while(!s.ended && !s.paused && source.call(s, i++, function () {
       if(!s.ended && !s.paused)
-          next()
+          process.nextTick(next);
     }))
       ;
   }

--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ var Stream = require('stream')
 module.exports =
 function from (source) {
   if(Array.isArray(source)) {
-    source = source.slice()
+		var source_index = 0, source_len = source.length;
     return from (function (i) {
-      if(source.length)
-        this.emit('data', source.shift())
+      if(source_index < source_len)
+        this.emit('data', source[source_index++])
       else
         this.emit('end')
       return true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "from",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Easy way to make a Readable Stream",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "from",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Easy way to make a Readable Stream",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "from",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Easy way to make a Readable Stream",
   "main": "index.js",
   "scripts": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,3 +1,5 @@
+[![TravisCI Build Status](https://travis-ci.org/nmhnmh/from.svg?branch=master)](https://travis-ci.org/nmhnmh/from)
+
 # from
 
 An easy way to create a `readable Stream`.

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,74 @@ exports['inc'] = function (test) {
   })
 }
 
+exports['inc - async'] = function (test) {
+
+  var fs = from(function (i, next) {
+    this.emit('data', i)
+    if(i >= 99)
+      return this.emit('end')
+		next();
+  })
+
+  spec(fs).readable().validateOnExit() 
+
+  read(fs, function (err, arr) {
+    test.equal(arr.length, 100)
+    test.done()
+  })
+}
+
+exports['large stream - from an array'] = function (test) {
+
+  var l = 100000
+    , expected = [] 
+
+  while(l--) expected.push(l * Math.random())
+
+  var fs = from(expected.slice())
+
+  spec(fs).readable().validateOnExit() 
+
+  read(fs, function (err, arr) {
+		a.deepEqual(arr, expected)
+    test.done()
+  })
+}
+
+exports['large stream - callback return true'] = function (test) {
+
+  var fs = from(function (i, next) {
+    this.emit('data', i)
+    if(i >= 99999)
+      return this.emit('end')
+		return true;
+  })
+
+  spec(fs).readable().validateOnExit() 
+
+  read(fs, function (err, arr) {
+    test.equal(arr.length, 100000)
+    test.done()
+  })
+}
+
+exports['large stream - callback call next()'] = function (test) {
+
+  var fs = from(function (i, next) {
+    this.emit('data', i)
+    if(i >= 99999)
+      return this.emit('end')
+		next();
+  })
+
+  spec(fs).readable().validateOnExit() 
+
+  read(fs, function (err, arr) {
+    test.equal(arr.length, 100000)
+    test.done()
+  })
+}
+
 exports['simple'] = function (test) {
 
   var l = 1000

--- a/test/index.js
+++ b/test/index.js
@@ -170,7 +170,8 @@ exports['simple (not strictly pausable) setTimeout'] = function (test) {
       if(_expected.length)
         self.emit('data', _expected.shift())
       else
-        self.emit('end') 
+        if(!self.ended)
+          self.emit('end')
       n()
     }, 3)
   })


### PR DESCRIPTION
* Use `process.nextTick()` to avoid maximum stack call issue when source using `next()`
* add tests to ensure no maximum stack call issue exists
* fix a hidden bug(`end` event emitted twice) inside a test case, which would trigger around once per 10 run, to make it more obvious, change the setTimeout delay from 3 to 5 and setInterval delay from 2 to 1, it will always fail
* Bump version numbers